### PR TITLE
カレンダー作成とゲスト作成のエラー解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,11 +51,17 @@ class ApplicationController < ActionController::Base
 
   def current_guest
     if session[:guest_user_id]
-      GuestUser.find(session[:guest_user_id])
-    else
-      guest = GuestUser.create!
-      session[:guest_user_id] = guest.id
-      guest
+      guest_user = GuestUser.find_by(id: session[:guest_user_id])
+      return guest_user if guest_user
     end
+
+    guest_user = GuestUser.create!
+    session[:guest_user_id] = guest_user.id
+    guest_user
+  rescue ActiveRecord::RecordNotFound
+    session.delete(:guest_user_id)
+    guest_user = GuestUser.create!
+    session[:guest_user_id] = guest_user.id
+    guest_user
   end
 end

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,0 +1,30 @@
+<%= form_with(model: @calendar, local: true) do |form| %>
+    <% if @calendar.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@calendar.errors.count, "error") %> prohibited this calendar from being saved:</h2>
+  
+        <ul>
+          <% @calendar.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  
+    <div class="field">
+      <%= form.label :title %>
+      <%= form.text_field :title %>
+    </div>
+  
+    <div class="field">
+      <%= form.label :image %>
+      <%= form.file_field :image %>
+    </div>
+  
+    <div class="actions">
+      <%= form.submit 'Create Calendar' %>
+    </div>
+  <% end %>
+  
+  <%= link_to 'Back', calendars_path %>
+  


### PR DESCRIPTION
Closes #38、Closes #40、Closes #41
トップページからカレンダーのタイトルを入力後、カレンダーの画面に飛べるようにするためにゲスト機能の見直しと、app/views/calendars/new.html.erbを追加。
スケジュール関係はmainブランチでの作業にて解決したため、こちらのブランチでクローズとする。